### PR TITLE
Fix import statement for Storybook blocks

### DIFF
--- a/apps/ui/src/stories/design-tokens/Theming.mdx
+++ b/apps/ui/src/stories/design-tokens/Theming.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls } from '@storybook/blocks';
+import { Meta, Story, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ThemeToggle, ThemeToggleGroup } from '../../components/ui/theme-toggle';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';


### PR DESCRIPTION
Update the import path for Storybook blocks to use the correct addon-docs module.